### PR TITLE
校对翻译

### DIFF
--- a/02.4-Prototype.md
+++ b/02.4-Prototype.md
@@ -194,6 +194,7 @@ private:
 ```
 
 To create a spawner for ghosts, you do:
+可以这样为ghosts创造spawner：
 
 ```cpp
 Spawner* ghostSpawner = new Spawner(spawnGhost);
@@ -202,7 +203,7 @@ Spawner* ghostSpawner = new Spawner(spawnGhost);
 ###Templates
 ###模板
 By now, most C++ developers are familiar with templates. Our spawner class needs to construct instances of some type, but we don’t want to hard code some specific monster class. The natural solution then is to make it a type parameter, which templates let us do:
-到目前为止，大部分的c++开发者已经熟悉模板了。我们的spawner类需要通过一些类型来构建一些对象实例。但是，我们并不想为每一种monster类硬编码一个类。把这些类型当作一个模板参数就成了很自然的解决方案。使用模板，我们可以有以下解决方案:
+到目前为止，大部分的C++开发者已经熟悉模板了。我们的spawner类需要通过一些类型来构建一些对象实例。但是，我们并不想为每一种monster类硬编码一个类。把这些类型当作一个模板参数就成了很自然的解决方案。使用模板，我们可以有以下解决方案:
 
 ```cpp
 class Spawner
@@ -230,7 +231,7 @@ Spawner* ghostSpawner = new SpawnerFor<Ghost>();
 #### First-class types
 #### 头等(First-class)类型
 The previous two solutions address the need to have a class, Spawner, which is parameterized by a type. In C++, types aren’t generally first-class, so that requires some gymnastics. If you’re using a dynamically-typed language like JavaScript, Python, or Ruby where classes are regular objects you can pass around, you can solve this much more directly.
-前面两种解决方案都强调我们需要有一种类型Spawner，它被参数化。在c++里面，类型并不是头等类型。如果你使用像Javascript, Python和Ruby这样的动态类型语言，它们把类当作是头等类型，class可以当作函数参数传递，你可以更直接地解决该问题。
+前面两种解决方案都强调我们需要有一种类型Spawner，它被参数化。在C++里面，类型并不是头等类型。如果你使用像Javascript, Python和Ruby这样的把类当作是头等类型的动态语言时，class可以当作函数参数传递，你可以更直接地解决该问题。
 
 In some ways, the Type Object pattern is another workaround for the lack of first-class types. That pattern can still be useful even in languages with them, though, because it lets you define what a “type” is. You may want different semantics than what the language’s built-in classes provide.
 在某些时候，Type Object模式是对于不支持class作为first-class的语言的解决方案。而且Type Object模式即使是对于把class当作first-class的语言，也是非常有用的，因为它可以让你定义具体的type是什么。因为你可能有时候想得到一些语言本身并不支持的类型特性。
@@ -261,7 +262,7 @@ To invoke a method, though, you look up the instance’s class, and then you loo
 为了调用该实例的一个方法，你需要从类的声明中查找这个方法，然后你再调用这个方法。实例的行为包含在class中。我们想要调用这些方法总会有不同级别的间接定向，这也意味着域(field)和方法(methods)是不同的。
 
 For example, to invoke a virtual method in C++, you look in the instance for the pointer to its vtable, then look up the method there.
-比如，为了调用c++里面的一个虚函数，你需要找到该对象实例的虚表的指针，然后通过该指针对调用实际的方法：
+比如，为了调用C++里面的一个虚函数，你需要找到该对象实例的虚表的指针，然后通过该指针对调用实际的方法：
 
 ![prototype-class](./res/prototype-class.png )
 
@@ -274,12 +275,12 @@ If that was all Self did, it would be hard to use. Inheritance in class-based la
 如果Self语言仅仅只是这样的话，那么它就太难以使用了。在基于class的语言里面，继承（除去它的缺点）给了我们一种机制，它可以重用多态的代码，并且可以消除一些重复。为了完成和继承一样的功能，Self可以使用委托（delegation）的方式。
 
 To find a field or call a method on some object, we first look in the object itself. If it has it, we’re done. If it doesn’t, we look at the object’s parent. This is just a reference to some other object. When we fail to find a property on the first object, we try its parent, and its parent, and so on. In other words, failed lookups are delegated to an object’s parent.
-想要查找一些对象的域或者调用它们的方法，我们可以直接从对象本身去查找。如果它有我们想要查找的内容，那么便直接返回。反之，我们则从它的父亲去查找 ，如果还是没有，则一直继续往上查找。直到找到，或者它没有父亲节点为止。换句话说，域的查找 会委托给它的父亲。
+想要查找一些对象的域或者调用它们的方法，我们可以直接从对象本身去查找。如果它有我们想要查找的内容，那么便直接返回。反之，我们则从它的父亲去查找，如果还是没有，则一直继续往上查找。直到找到，或者它没有父亲节点为止。换句话说，域的查找会委托给它的父亲。
 
 ![prototype-delegate.png](./res/prototype-delegate.png )
 
 Parent objects let us reuse behavior (and state!) across multiple objects, so we’ve covered part of the utility of classes. The other key thing classes do is give us a way to create instances. When you need a new thingamabob, you can just do new Thingamabob(), or whatever your preferred language’s syntax is. A class is a factory for instances of itself.
-父亲对象让我们可以在多个对象之间重用一些行为和状态，那么，我们现在已经覆盖了class的部分功能了。对于class而言，还有一个很重要的功能就是允许以类为模板创建一些实例对象。当你需要一个新的thingamabob，你只需要调用new Thingamabob()就可以了。一个类就是一个对象工厂。
+父亲对象让我们可以在多个对象之间重用一些行为和状态，那么，我们现在已经覆盖了class的部分功能了。对于class而言，还有一个很重要的功能就是允许以类为模板创建一些实例对象。当你需要一个新的东西，你只需要调用new 东西()就可以了。一个类就是一个对象工厂。
 
 Without classes, how do we make new things? In particular, how do we make a bunch of new things that all have stuff in common? Just like the design pattern, the way you do this in Self is by cloning.
 如果没有类的话，那我们怎么创建新事物呢？更具体一点，我们怎么创建一些事物，它们具有相同的行为呢？就像我们本章所讲的设计模式一样，Self实现的方式是采用clone。
@@ -288,9 +289,11 @@ In Self, it’s as if every object supports the Prototype design pattern automat
 在Self里面，每一个对象都自动支持原型模式。任意对象都可以被克隆。如果想要创建一系列类似的对象，就可以这样：
 
 1. Beat one object into the shape you want. You can just clone the base Object built into the system and then stuff fields and methods into it.
-1. 打造一个你想要的对象。你可以先克隆一个Base对象，然后再塞一些域和方法给这个克隆出来的对象。
-
 2. Clone it to make as many… uh… clones as you want.
+
+&nbsp;
+
+1. 打造一个你想要的对象。你可以先克隆一个Base对象，然后再塞一些域和方法给这个克隆出来的对象。
 2. 克隆N个此对象的实例。好吧，克隆你想要克隆的数量就够了。
 
 This gives us the elegance of the Prototype design pattern without the tedium of having to implement clone() ourselves; it’s built into the system.
@@ -317,7 +320,7 @@ Maybe this is because my prior experience is in class-based languages, so my min
 不过，也许是因为我之前的语言经验是面向对象的原因，我的大脑被OOP所固化了。但是，我的预感是大多数人只会喜欢定义清楚的事物。
 
 In addition to the runaway success of class-based languages, look at how many games have explicit character classes and a precise roster of different sorts of enemies, items, and skills, each neatly labeled. You don’t see many games where each monster is a unique snowflake, like “sort of halfway between a troll and a goblin with a bit of snake mixed in”.
-撇去class的语言的成功，让我们看一看有多少游戏里面会定义主角类，还有各种各样的怪我类，装备类，技能类等等。你很少看到很多游戏，它的怪物是一个独特的雪巫，就像“一个旋转的小妖精+一点点蛇精混入其中”。
+撇去class的语言的成功，让我们看一看有多少游戏里面会定义主角类，还有各种各样的怪我类，装备类，技能类等等。你几乎看不到有什么游戏，它的怪物是一个独特的雪巫，就像“一个旋转的小妖精+一点点蛇精混入其中”。
 
 While prototypes are a really cool paradigm and one that I wish more people knew about, I’m glad that most of us aren’t actually programming using them every day. The code I’ve seen that fully embraces prototypes has a weird mushiness to it that I find hard to wrap my head around.
 当然，原型是一个很酷的范式，我希望有很多人可以了解它们。我很高兴我们中的大部分人并没有用它来写代码。那种基于原型的代码看起来非常奇葩，而且我们的大脑很难适应它。
@@ -502,7 +505,7 @@ Since the archer and wizard have the grunt as their prototype, we don’t have t
 因为弓箭手和巫师都把grunt当作它们的原型，我们就没有必要再重复定义生命值，防御力和弱点了。这里面我们给数据模型添加的逻辑也非常地简单--简单的单一委托---但是，我们还是没有完全摆脱重复代码。
 
 One interesting thing to note here is that we didn’t set up a fourth “base goblin” abstract prototype for the three concrete goblin types to delegate to. Instead, we just picked one of the goblins who was the simplest and delegated to it.
-一个有意思的事情 是，我们没有创建第四种“基本哥布林”抽象原型，然后让其它具体的哥布林来把原型对象指向它。我们采用的是另一种方法，我们每次都让原型对象指向一个最简单的哥布林，然后委托给它。
+一个有意思的事情是，我们没有创建第四种“基本哥布林”抽象原型，然后让其它具体的哥布林来把原型对象指向它。我们采用的是另一种方法，我们每次都让原型对象指向一个最简单的哥布林，然后委托给它。
 
 That feels natural in a prototype-based system where any object can be used as a clone to create new refined objects, and I think it’s equally natural here too. It’s a particularly good fit for data in games where you often have one-off special entities in the game world.
 这里感觉很自然，在一个基于原型的系统里面，任意对象都可以被克隆来创建出一个新的细节的对象，我觉得我们这里的数据模型也是一样。它特别适合于游戏里面的数据建模，在那里，你经常需要一系列特殊的游戏实体。

--- a/02.4-Prototype.md
+++ b/02.4-Prototype.md
@@ -9,7 +9,7 @@ The first time I heard the word “prototype” was in Design Patterns. Today, i
 
 Pretend we’re making a game in the style of Gauntlet. We’ve got creatures and fiends swarming around the hero, vying for their share of his flesh. These unsavory dinner companions enter the arena by way of “spawners”, and there is a different spawner for each kind of enemy.
 
-设想我们正在开发一款Gauntlet类型的游戏。我们的主角旁边挤满了怪物，它们正在抢食这块鲜肉呢。这场盛大的饕餮盛宴，让我们的"Spawners"登上了舞台，对于每一种不同类型的敌人，我们都有一个spawner,用来产生对应的怪物。
+设想我们正在开发一款类似Gauntlet的游戏。我们的主角旁边挤满了怪物，它们正在抢食这块鲜肉呢。这场盛大的饕餮盛宴，让我们的"Spawners"登上了舞台，对于每一种不同类型的敌人，我们都有一个spawner,用来产生对应的怪物。
 
 For the sake of this example, let’s say we have different classes for each kind of monster in the game — Ghost, Demon, Sorcerer, etc., like:
 考虑到我们刚刚所举的例子，我们假设游戏中有以下种类的怪物: Ghost(幽灵)，Demon(恶魔)和Sorcerer(术士)：
@@ -142,7 +142,7 @@ One neat part about this pattern is that it doesn’t just clone the class of th
 关于这个模式，有一点比较优雅的是，它不仅仅是克隆原型类，而且它也克隆了对象的状态。这意味着，我们可以制作一些spawner，它可以用来生成极速ghost和龟速ghost。实现这种spawner也非常简单，只需要创建一个相应类型的monster类再把它当作模板传给spawner的构造函数即可。
 
 I find something both elegant and yet surprising about this pattern. I can’t imagine coming up with it myself, but I can’t imagine not knowing about it now that I do.
-我发现关于此模式还有一些优雅的、甚至会让你惊讶的内容。我甚至不敢相信我居然发现它们了，但是我还是....(todo:这个地方实在是不知道怎么翻译了。)
+我发现这个模式在某些层面上是如此优雅和令人惊讶。我自己的确想不到这一点，但现在的我根本无法想象我不知道这种特性会是怎样的。
 
 ###How well does it work?
 ###刚才的方法到底有多好？
@@ -413,13 +413,13 @@ When your game’s data reaches a certain size, you really start wanting similar
 当你的游戏数据到达一个大小的时候，你会开始想要一些类似的特性。数据建模是一个很深的主题，我不可能涉及它的方方面面。但是，我希望可以抛砖引玉，让你可以在自己的游戏里面：使用原型和委托来重用数据。
 
 Let’s say we’re defining the data model for the shameless Gauntlet rip-off I mentioned earlier. The game designers need to specify the attributes for monsters and items in some kind of files.
-好了，让我们为我之前提到的游戏Gauntlet rip-off游戏进行数据建模。游戏设计者需要给monsters和items设计属性，并且把它们存放于文件之中。
+比方说，我们正在为我之前提到的抄袭（羞愧地）Gauntlet的游戏进行数据建模。游戏设计者需要给monsters和items设计属性，并且把它们存放于文件之中。
 
 I mean completely original title in no way inspired by any previously existing top-down multi-player dungeon crawl arcade games. Please don’t sue me.
-todo：xxx请不要控告我。(这段话感觉没必要翻译啊)
+我说的游戏名绝对是原创的，肯定不是受之前某款往地下延伸、多人地牢探险游戏。求别起诉我。
 
 One common approach is to use JSON. Data entities are basically maps, or property bags, or any of a dozen other terms because there’s nothing programmers like more than inventing a new name for something that already has one.
-一个通用的做法是使用JSON. 数据实体一般都是map，或者属性map，或者其它术语。因为程序员们最喜欢对已经存在的事物去发明新名称啦。
+一个通用的做法是使用JSON. 数据实体一般都是map，或者属性map，或者其它术语。因为程序员们最喜欢对已经存在的事物去发明新名称。
 
 We’ve re-invented them so many times that Steve Yegge calls them “The Universal Design Pattern”.
 我们已经重新发明它们n次了，Steve Yegge管它叫做“The Universal Design Pattern”.
@@ -439,7 +439,7 @@ So a goblin in the game might be defined something like this:
 ```
 
 This is pretty straightforward and even the most text-averse designer can handle that. So you throw in a couple of sibling branches on the Great Goblin Family Tree:
-这个看起来非常地直白明了而且甚至是最讨厌文字的设计师也能够处理它们。所以，你可以在非常大的哥布林家族树里面再添加一些树干啦：
+这个看起来非常地直白明了而且甚至是最讨厌文字的设计师也能够处理它们。所以，你可以在非常大的哥布林家族树里面再添加一些树干：
 
 ```cpp
 {

--- a/02.5-Singleton.md
+++ b/02.5-Singleton.md
@@ -66,9 +66,7 @@ they must be coordinated with each other. If we start one call to create a file
 and another one to delete that same file, our wrapper needs to be aware of both
 to make sure they don't interfere with each other.
 
-比如说一个封装了底层文件API的类。因为文件操作需要一定时间去完成，我们的类将异步地处理。这意味着许多
-操作可以同时进行，所以他们必须相互协调。如果我们一方面创建文件，一方面去删除这个文件，我们的封装类就
-必须全部感知，并确保他们不会相互干扰。
+比如说一个封装了底层文件API的类。因为文件操作需要一定时间去完成，我们的类将异步地处理。这意味着许多操作可以同时进行，所以他们必须相互协调。如果我们一方面创建文件，一方面去删除这个文件，我们的封装类就必须知悉，并确保他们不会相互干扰。
 
 To do this, a call into our wrapper needs to have access to every previous
 operation. If users could freely create instances of our class, one instance
@@ -86,16 +84,14 @@ Several different systems in the game will use our file system wrapper: logging,
 content loading, game state saving, etc. If those systems can't create their own
 instances of our file system wrapper, how can they get ahold of one?
 
-游戏中一些不同的系统需要用到我们的文件系统封装类：日志记录、文件加载、游戏保存等等。如果这些系统不能够创建
-它们各自的文件封装类的实例，它们如果去得到一个呢？
+游戏中一些不同的系统需要用到我们的文件系统封装类：日志记录、文件加载、游戏保存等等。如果这些系统不能够创建它们各自的文件封装类的实例，它们如何去得到一个呢？
 
 Singleton provides a solution to this too. In addition to creating the single
 instance, it also provides a globally available method to get it. This way,
 anyone anywhere can get their paws on our blessed instance. All together, the
 classic implementation looks like this:
 
-单件为此提供了一个解决方法。除了创建一个单独的实例外，它还提供一个全局的方法去得到这个实例。这样，
-在其他任何地方就都能等到这个实例了。总体说来，这个类的实现起来像下面这个样子：
+单例为此提供了一个解决方法。除了创建一个单独的实例外，它还提供一个全局的方法去得到这个实例。这样，在其他任何地方就都能等到这个实例了。总体说来，这个类的实现起来像下面这个样子：
 
 ```
 class FileSystem
@@ -121,8 +117,8 @@ method grants access to the instance from anywhere in the codebase. It is also
 responsible for instantiating the singleton instance lazily the first time
 someone asks for it.
 
-`instance_`这个静态成员保存这这个类的一个实例，私有的构造函数确保它是唯一的一个实例。
-公开的静态函数`instance()`提供了一个方法，能在其他地方得到这个实例。它也负责在第一次访问的时候初始化这个实例，也就是延时创建。
+`instance_`这个静态成员保存这这个类的一个实例，私有的构造函数确保它是*唯一*的一个实例。
+公开的静态函数`instance()`提供了一个方法，能在其他地方得到这个实例。它也负责在第一次访问的时候初始化这个实例，也就是惰性创建。
 
 A modern take looks like this:
 
@@ -160,15 +156,14 @@ different question! This just ensures that its *initialization* is.
 
 </aside>
 
-## Why We Use It 我们为什么使用
+## Why We Use It 我们为什么用它
 
 It seems we have a winner. Our file system wrapper is available wherever we need
-it without the tedium of passing it around everywhere. The class itself cleverly
-ensures we won't make a mess of things by instantiating a couple of instances.
+it without the tedium of passing it around everywhere. The class itself cleverly ensures we won't make a mess of things by instantiating a couple of instances.
 It's got some other nice features too:
 
-看起来我们取得了成效。我们的文件封装类能够在任何地方使用而不必将它传递的到处都是。这个类本身聪明
-的保证了我们不会初始化多个实例而将事情弄糟。它还具有一些额外的优良特性。
+看起来我们取得了成效。我们的文件封装类能够在任何地方使用而不必将它传递的到处都是。这个类本身聪明地保证了我们不会初始化多个实例而将事情弄糟。
+它还具有一些额外的优良特性。
 
 *   **It doesn't create the instance if no one uses it.** Saving memory and CPU
     cycles is always good. Since the singleton is initialized only when it's
@@ -187,15 +182,14 @@ It's got some other nice features too:
     -- the compiler does not guarantee the order in which statics are
     initialized relative to each other.
     
-    **它在运行期初始化**一个常见的单件替代品是包含多个静态成员的类。我喜欢简单的方案，所以我尽可能使	用静态类而不是单件。但是静态类有一个缺点：自动初始化。编译器早在`main()`函数调用之前就初始	化静态成员了。这意味着它不能使用只有游戏运行起来才能知道的信息（比如，文件配置）。它还意味	着它们之间不能相互依赖——编译器不能保证它们之间的初始化的顺序。
+    **它在运行期初始化**一个常见的单件替代品是包含多个静态成员的类。我喜欢简单的方案，所以我尽可能使用静态类而不是单件。但是静态类有一个缺点：自动初始化。编译器早在`main()`函数调用之前就初始化静态成员了。这意味着它不能使用只有游戏运行起来才能知道的信息（比如，文件配置）。它还意味着它们之间不能相互依赖——编译器不能保证它们之间的初始化的顺序。
 
     Lazy initialization solves both of those problems. The singleton will be
     initialized as late as possible, so by that time any information it needs
     should be available. As long as they don't have circular dependencies, one
     singleton can even refer to another when initializing itself.
     
-    延时初始化解决了以上所有问题。单件会尽可能的延时创建，所以此时它们需要的信息都应该是可以得到的。只要
-    不是循环依赖，一个单件在初始化的时候可以依赖另外一个单件。
+    惰性初始化解决了以上所有问题。单件会尽可能的延时创建，所以此时它们需要的信息都应该是可以得到的。只要不是循环依赖，一个单件在初始化的时候可以依赖另外一个单件。
 
 *   **You can subclass the singleton.** This is a powerful but often overlooked
     capability. Let's say we need our file system wrapper to be cross-platform.
@@ -270,7 +264,7 @@ It's got some other nice features too:
 
     The clever part is how the instance is created:
     
-    聪明之处是如何创建实例的：
+    巧妙的地方在于如何创建实例：
 
     ```
     FileSystem& FileSystem::instance()
@@ -322,8 +316,7 @@ and shipped good games. As games got bigger and more complex, architecture and
 maintainability started to become the bottleneck. We struggled to ship games not
 because of hardware limitations, but because of *productivity* limitations.
 
-当游戏还是车库里的几个家伙写的时候，推动硬件要比象牙塔软件工程准则更为重要。老式C语言和汇编程序员使用
-全局和静态代码而没有任何问题，并开发出优秀的游戏。随着游戏变得更大更复杂，
+当游戏还是车库里的几个家伙写的时候，推动硬件要比象牙塔软件工程准则更为重要。老式C语言和汇编程序员使用全局和静态代码而没有任何问题，并开发出优秀的游戏。随着游戏变得更大更复杂，
 架构和可维护性开始变为短板。我们挣扎着开发游戏不是因为硬件限制，而是因为*开发效率*限制。
 
 So we moved to languages like C++ and started applying some of the hard-earned
@@ -348,13 +341,12 @@ variables are bad for a variety of reasons:
     compiler to optimize, and let you do neat things like memoization where you
     cache and reuse the results from previous calls to the function.
     
-    >计算机科学家称不访问或者不修改全局状态的函数为“纯函数”。~TO-DO~:纯函数易于理解，利于编译器优化，并
-    让你做一些灵巧的事，比如记忆缓存和重用之前调用的结果。
+    >计算机科学家称不访问或者不修改全局状态的函数为“纯函数”。纯函数易于理解，利于编译器优化，并让你做一些灵巧的事，比如记忆缓存和重用之前调用的结果。
 
     >While there are challenges to using purity exclusively, the benefits are
     enticing enough that computer scientists have created languages like Haskell
     that *only* allow pure functions.
-    >因为全部使用纯函数有不少挑战，但是优势足够诱使计算机科学家发明Haskell这样*只*允许存函数的语言。
+    >虽然专门使用纯函数有不少挑战，但是它带来的利益足够让计算机科学家发明比如Haskell这种*只*允许纯函数的语言。
 
     </aside>
 
@@ -365,9 +357,7 @@ variables are bad for a variety of reasons:
     lines of code at three in the morning trying to find the one errant call
     that's setting a static variable to the wrong value.
 
-    现在，让我们来看这个函数中间的`SomeClass::getSomeGlobalData()`这个调用。为了搞清楚其
-    中发生了什么，我们需要查看整个代码库来看是谁访问了全局状态。在你不得不凌晨3点`grep`百万行
-    代码来找出究竟是那一个错误的调用将一个静态变量设置错了之前，你是不会真正痛恨全局状态的。
+    现在，让我们来看这个函数中间的`SomeClass::getSomeGlobalData()`这个调用。为了搞清楚其中发生了什么，我们需要查看整个代码库来看是谁访问了全局状态。在你不得不凌晨3点`grep`百万行代码来找出究竟是那一个错误的调用将一个静态变量设置错了之前，你是不会真正痛恨全局状态的。
     
 *   **They encourage coupling.** The new coder on your team isn't familiar with
     your game's beautifully maintainable loosely coupled architecture, but he's
@@ -379,9 +369,7 @@ variables are bad for a variety of reasons:
     constructed architecture.
     
     **这了促进了耦合。** 你团队的开发新手还不熟悉游戏优美可维护的松耦合架构，但是他却有了第一项任务：
-    让石头撞在地上时发出声音。你我都知道，我们不想让物理引擎代码和*音频*代码耦合起来，但是新手
-    只是一心想完成任务。不幸的是，我们的`AudioPlayer`这个类实例是全局可见的。所以，
-    在一小段`#include`之后，我们的新伙伴扰乱了一个仔细构建的架构。
+    让石头撞在地上时发出声音。你我都知道，我们不想让物理引擎代码和*音频*代码耦合起来，但是新手只是一心想完成任务。不幸的是，我们的`AudioPlayer`这个类实例是全局可见的。所以，在一小段`#include`之后，我们的新伙伴扰乱了一个仔细构建的架构。
 
     Without a global instance of the audio player, even if he *did* `#include`
     the header, he still wouldn't be able to do anything with it. That
@@ -401,9 +389,7 @@ variables are bad for a variety of reasons:
     threads are doing to it. That path leads to deadlocks, race conditions, and
     other hell-to-fix thread-synchronization bugs.
 
-    **它对并发不友好**现在离在单核上运行游戏的日子已经很远了。现在的代码必须在多线程情况下至少能够*工作*，
-    即使没有利用到并发的全部优势。当我们设置为全局时，我们创建了一段内存，每个线程都能够查看和修改它，
-    不管他们是否知道其他线程正在操作它。这有可能导致死锁，条件竞争，和其他一些难以修复的线程同步的Bug。
+    **它对并发不友好。**现在离在单核上运行游戏的日子已经很远了。现在的代码必须在多线程情况下至少能够*工作*，即使没有利用到并发的全部优势。当我们设置为全局时，我们创建了一段内存，每个线程都能够查看和修改它，不管他们是否知道其他线程正在操作它。这有可能导致死锁，条件竞争，和其他一些难以修复的线程同步的Bug。
 
 Issues like these are enough to scare us away from declaring a global variable,
 and thus the Singleton pattern too, but that still doesn't tell us how we
@@ -449,17 +435,14 @@ game can benefit from being able to log diagnostic information. However, passing
 an instance of our `Log` class to every single function clutters the method
 signature and distracts from the intent of the code.
 
-这两个问题的后者，便利的访问，是我们使用单件模式的主要原因。比如一个日志类。许多游戏中的模块
-都能够从日志模块记录诊断信息中获得好处。但是，将我们`Log`类的实例传递给每个函数扰乱了函数签名，
-并与代码意图分散。
+这两个问题的后者，便利的访问，是我们使用单件模式的主要原因。比如一个日志类。许多游戏中的模块都能够从日志模块记录诊断信息中获得好处。但是，将我们`Log`类的实例传递给每个函数扰乱了函数签名，并与代码意图分散。
 
 The obvious fix is to make our `Log` class a singleton. Every function can then
 go straight to the class itself to get an instance. But when we do that, we
 inadvertently acquire a strange little restriction. All of a sudden, we can no
 longer create more than one logger.
 
-很显然，修正这点就是让我们的`Log`类变为一个单件。每个函数都能直接通过这个类得到这个类的实例。
-但是当我们这样做时，我们奇怪的得到了一个限制。突然的，我们不能够创建更多的日志器了。
+很显然，修正这点就是让我们的`Log`类变为一个单件。每个函数都能直接通过这个类得到这个类的实例。但是当我们这样做时，我们奇怪的得到了一个限制。突然的，我们不能够创建更多的日志器了。
 
 At first, this isn't a problem. We're writing only a single log file, so we only
 need one instance anyway. Then, deep in the development cycle, we run into
@@ -467,9 +450,7 @@ trouble. Everyone on the team has been using the logger for their own
 diagnostics, and the log file has become a massive dumping ground. Programmers
 have to wade through pages of text just to find the one entry they care about.
 
-起初，这并不是一个问题，我们只写一个日志文件，所以我们只需要一个日志实例。之后，随着开发周期的深入，
-我们陷入了麻烦。团队的每个人都使用这个日志器来记录他们自己的诊断信息，这个日志文件已经成为了一个巨大的垃圾场。
-程序员们需要过滤几页的文本来找到他们关心的那条记录。
+起初，这并不是一个问题，我们只写一个日志文件，所以我们只需要一个日志实例。之后，随着开发周期的深入，我们陷入了麻烦。团队的每个人都使用这个日志器来记录他们自己的诊断信息，这个日志文件已经成为了一个巨大的垃圾场。程序员们需要过滤几页的文本来找到他们关心的那条记录。
 
 We'd like to fix this by partitioning the logging into multiple files. To do
 this, we'll have separate loggers for different game <span
@@ -477,7 +458,7 @@ name="worse">domains</span>: online, UI, audio, gameplay. But we can't. Not only
 does our `Log` class no longer allow us to create multiple instances, that
 design limitation is entrenched in every single call site that uses it:
 
-我们可以通过将日子分割为不同的文件来修正。要做到这单，我们对不同的游戏区域有单独的日志器：
+我们可以通过将日子分割为不同的文件来修正。要做到这点，我们对游戏不同的区域有单独的日志器：
 在线、界面、音频、游戏操作。但是我们不能。不仅仅是应为我们的`Log`类不允许我们创建多个实例，
 还有这个模式的设计缺陷根深到每次调用的地方：
 
@@ -513,10 +494,8 @@ control when that's going to happen. If we let it lazy-initialize itself the
 first time a sound plays, that could be in the middle of an action-packed part
 of the game, causing visibly dropped frames and stuttering gameplay.
 
-为了满足PC游戏内存和软件效率的需求，延时实例化是一个聪明的技巧。游戏是个与众不同的怪兽。实例化
-一个系统需要花费时间:分配内存，加载资源等等。如果实例化音频系统需要花费几百毫秒，
-我们需要控制住何时实例化。如果我们让它在第一次播放声音的时候延时实例化，这有可能在游戏正酣的时候，
-导致明显的掉帧和游戏卡顿。
+为了满足PC游戏内存和软件效率的需求，惰性实例化是一个聪明的技巧。游戏是个与众不同的怪兽。实例化
+一个系统需要花费时间:分配内存，加载资源等等。如果实例化音频系统需要花费几百毫秒，我们需要控制住何时实例化。如果我们让它在第一次播放声音的时候惰性实例化，这有可能在游戏正酣的时候，导致明显的掉帧和游戏卡顿。
 
 Likewise, games generally need to closely control how memory is laid out in the
 heap to avoid <span name="fragment">fragmentation</span>. If our audio
@@ -524,21 +503,20 @@ system allocates a chunk of heap when it initializes, we want to know *when*
 that initialization is going to happen, so that we can control *where* in the
 heap that memory will live.
 
-同样的，游戏通常需要仔细的控制内存在堆中的布局来防止分段。如果我们的音频系统在实例化时分配了内存，
-我们需要知道实例化发生的*时间*，以便让我们控制它在堆中的内存*布局*。
+同样的，游戏通常需要仔细的控制内存在堆中的布局来防止分段。如果我们的音频系统在实例化时分配了内存，我们需要知道实例化发生的*时间*，以便让我们控制它在堆中的内存*布局*。
 
 <aside name="fragment">
 
->See <a class="pattern" href="object-pool.html">Object Pool</a> for a detailed
+>See <a class="pattern" href="06.3-Object%20Pool.html">Object Pool</a> for a detailed
 explanation of memory fragmentation.
 
->查看 <a class="pattern" href="object-pool.html">对象池</a> 获得内存分段的详细解释。
+>查看 <a class="pattern" href="06.3-Object%20Pool.html">对象池</a> 获得内存分段的详细解释。
 </aside>
 
 Because of these two problems, most games I've seen don't rely on lazy
 initialization. Instead, they implement the Singleton pattern like this:
 
-介于这两点问题，我见过的大部分游戏都不依赖延时初始化。相反，他们像这样实现单件模式。
+介于这两点问题，我见过的大部分游戏都不依赖惰性初始化。相反，他们像这样实现单件模式。
 
 ```
 class FileSystem
@@ -559,7 +537,7 @@ With a static instance, we can no longer use polymorphism, and the class must be
 constructible at static initialization time. Nor can we free the memory that the
 instance is using when not needed.
 
-这解决的延时初始化的问题，但是这也丢失了单件比一个全局变量更好的几个特性。作为一个静态实例，
+这解决的惰性初始化的问题，但是这也丢失了单件比一个全局变量更好的几个特性。作为一个静态实例，
 我们不能够使用多态了，并且这个类必须能够在静态初始化的时候构造。我们也不能够在不需要这个
 类的时候释放这段内存。
 
@@ -570,9 +548,7 @@ entirely and use static functions instead? Calling `Foo::bar()` is simpler than
 `Foo::instance().bar()`, and also makes it clear that you really are dealing
 with static memory.
 
-与创建单件不同，这里我们真正有的只是一个静态类。这不完全是一件坏事，但是如果你想要的仅仅是静态类，
-何不移除`instance()`这个方法而使用静态函数呢？调用`Foo::bar()`要比`Foo::instance().bar()`
-简单不说，还能澄清你正在使用静态内存。
+与创建单件不同，这里我们真正有的只是一个静态类。这不完全是一件坏事，但是如果你想要的仅仅是静态类，何不移除`instance()`这个方法而使用静态函数呢？调用`Foo::bar()`要比`Foo::instance().bar()`简单不说，还能澄清你正在使用静态内存。
 
 <aside name="static">
 
@@ -582,8 +558,7 @@ fix every call site. In theory, you don't have to do that with singletons
 because you could be passing the instance around and calling it like a normal
 instance method.
 
-通常关于静态类和单件的争论是，如果之后你决定将一个静态类转变为非静态类，你必须修改每处调用的代码。
-理论上，对于单件，你可以不必这样做，因为你可以将实例相互传递并且像一个普通实例一样去调用。
+通常关于静态类和单件的争论是，如果之后你决定将一个静态类转变为非静态类，你必须修改每处调用的代码。理论上，对于单件，你可以不必这样做，因为你可以将实例相互传递并且像一个普通实例一样去调用。
 
 In practice, I've never seen it work that way. Everyone just does
 `Foo::instance().bar()` in one line. If we changed Foo to not be a
@@ -595,15 +570,14 @@ a simpler class and a simpler syntax to call into it.
 
 </aside>
 
-## What We Can Do Instead 有何替代
+## What We Can Do Instead 那么我该怎么做
 
 If I've accomplished my goal so far, you'll think twice before you pull
 Singleton out of your toolbox the next time you have a problem. But you still
 have a problem that needs solving. What tool *should* you pull out? Depending on
 what you're trying to do, I have a few options for you to consider, but first...
 
-如果现在我完成了目标，当你下次遇到问题时，在你祭出单件大法时会多考虑几次。但你还有一个
-问题有待解决。你应该使用什么样的方法？这要取决于你想要做什么，我有几个选项可供参考，不过首先...
+如果我已经达到了我想要的效果，你下次遇到问题时就会多考虑下是否使用单例模式。但是你仍然被一个问题所困扰，那就是你*该*用什么？取决于你想做什么。我个人有一些建议，但是首先……
 
 ### See if you need the class at all 看你究竟是否需要类
 
@@ -768,9 +742,7 @@ first, then we've ensured no other code can either get at that instance or
 create their own. The class ensures the single instantiation requirement it
 cares about, but it doesn't dictate how the class should be used.
 
-这个类允许任何人创建它，但是如果你想要创建超过一个实例时，它会断言并且失败。一旦正确的代码帅先创建了
-一个实例，我们保证其他代码即不能得到这个实例也不能创建一个自己的实例。这个类保证了它单个
-实例的需求，但是它没指示这个类该如何使用。
+这个类允许任何人创建它，但是如果你想要创建超过一个实例时，它会断言并且失败。一旦正确的代码率先创建了一个实例，我们就保证了其他代码即不能得到这个实例也不能创建一个自己的实例。这个类保证了它单个实例的需求，但是它没指示这个类该如何使用。
 
 <aside name="assert">
 
@@ -791,17 +763,14 @@ define contracts between regions of code. If a function asserts that one of
 its arguments is not `NULL`, that says, "The contract between me and the
 caller is that I will not be passed `NULL`."
 
->一个`assert()`意味着，“我确保这个应该始终为true，如果不是，这就是一个bug，并且我想*立刻*停止
-以便你能修复它。”这可以让你在代码域之间定义约定。如果一个函数断言它的某个参数不为`NULL`，也就是说，
-“函数和调用着之间的契约就是不能够传递`NULL`。”
+>一个`assert()`意味着，“我确保这个应该始终为true，如果不是，这就是一个bug，并且我想*立刻*停止以便你能修复它。”这可以让你在代码域之间定义约定。如果一个函数断言它的某个参数不为`NULL`，也就是说，“函数和调用者之间的契约就是不能够传递`NULL`。”
 
 >Assertions help us track down bugs as soon as the game does something
 unexpected, not later when that error finally manifests as something
 visibly wrong to the user. They are fences in your codebase, corralling bugs
 so that they can't escape from the code that created them.
 
->断言帮助我们在游戏做一些未预料的事情时立刻开始追踪bug，而不是等到错误体现在用户可见的错误上。
-它们是代码库的围栏，圈住bug，以防它在产生的代码之处逃离出去。
+>断言帮助我们在游戏做一些未预料的事情时立刻开始追踪bug，而不是等到错误体现在用户可见的错误上。它们是代码库的围栏，圈住bug，以防它在产生的代码之处逃离出去。
 </aside>
 
 The downside with this implementation is that the check to prevent multiple
@@ -819,8 +788,7 @@ to get our hands on an object we need to use in a lot of different places. That
 ease comes at a cost, though -- it becomes equally easy to get our hands on the
 object in places where we *don't* want it being used.
 
-便利的访问是我们使用单件的主要原因。它让我们在许多不同地方需要使用时能简单的得到一个对象。这种便利也有代价，
-——它也使得我们在不想使用的地方也可以轻松的得到这个对象。
+便利的访问是我们使用单件的主要原因。它让我们在许多不同地方需要使用时能简单的得到一个对象。这种便利也有代价，那就是 —— 它也使得我们在不想使用的地方也可以轻松地得到这个对象。
 
 The general rule is that we want variables to be as narrowly scoped as possible
 while still getting the job done. The smaller the scope an object has, the fewer
@@ -828,15 +796,13 @@ places we need to keep in our head while we're working with it. Before we take
 the shotgun approach of a singleton object with *global* scope, let's consider
 other ways our codebase can get access to an object:
 
-通用的原则是，在保证功能的情况下将变量限制在一个狭窄的范围内。对象的作用域越小，我们需要记住到它
-的地方就越少。在我们直接了当的通过*全局*作用域来访问一个单件对象时，让我们考察一下我们代码访问一个对象的其他方式：
+通用的原则是，在保证功能的情况下将变量限制在一个狭窄的范围内。对象的作用域越小，我们需要记住到它的地方就越少。在我们直截了当地通过*全局*作用域来访问一个单件对象前，让我们想一下通过其他途径来访问一个对象：
 
  *  **Pass it in.** The <span name="di">simplest</span> solution, and often the
     best, is to simply pass the object you need as an argument to the functions
     that need it. It's worth considering before we discard it as too cumbersome.
     
-    **传递进去** 最简单，通常也是最好的方法就是简单的将这个对象当作一个参数传递给需要它的函数。当
-    我们觉得笨重而抛弃它之前，它是值得考虑的。
+    **传递进去** 最简单，通常也是最好的方法就是简单的将这个对象当作一个参数传递给需要它的函数。当我们觉得笨重而抛弃它之前，它是值得考虑的。
 
     <aside name="di">
 
@@ -864,9 +830,8 @@ other ways our codebase can get access to an object:
     strange to see `Log` show up in its argument list, so for cases like that
     we'll want to consider other options.
 
-	  另一方面，一个对象不属于某个函数的签名。举个例子，一个操作AI的函数可能也需要写一个日志文件，
-    但是记录日志并不是它主要关心的事情。在它的参数列表中发现有`Log`会很奇怪，所以为了这些情况，
-    我们需要参考其他方法。
+	另一方面，一个对象不属于某个函数的签名。举个例子，一个操作AI的函数可能也需要写一个日志文件，
+	但是记录日志并不是它主要关心的事情。在它的参数列表中发现有`Log`会很奇怪，所以为了这些情况，我们需要参考其他方法。
     <aside name="aop">
 
     >The term for things like logging that appear scattered throughout a codebase
@@ -921,11 +886,11 @@ other ways our codebase can get access to an object:
     but every derived entity does using `getLog()`. This pattern of letting
     derived objects implement themselves in terms of protected methods provided
     to them is covered in the <a class="pattern"
-    href="subclass-sandbox.html">Subclass Sandbox</a> chapter.
+    href="04.2-Subclass%20Sandbox.html">Subclass Sandbox</a> chapter.
     
     这保证了在`GameObject`之外没有能访问`Log`对象的代码，但是每个派生类能够通过`getLog()`访问。
     这种让派生类在所提供的保护方法中提供实现的模式在 <a class="pattern"
-    href="subclass-sandbox.html">子类沙盒</a> 章节中讨论.
+    href="04.2-Subclass%20Sandbox.html">子类沙盒</a> 章节中讨论.
 
     <aside name="gameobject">
 
@@ -951,14 +916,13 @@ other ways our codebase can get access to an object:
     couple of globally available objects, such as a single `Game` or `World`
     object representing the entire game state.
 
-    **通过其他全局对象访问它。** 将*所有*全局状态都移除令人敬佩，但是不够实际。许多代码库
+    **通过其他全局对象访问它。** 将*所有*全局状态都移除令人敬佩，但是不切实际。许多代码库
     仍然有一些全局对象，比如一个单独的代表整个游戏状态的`Game`或者`World`对象。
 
     We can reduce the number of global classes by piggybacking on existing ones
     like that. Instead of making singletons out of `Log`, `FileSystem`, and
     `AudioPlayer`, do this:
-    我们像这样够通过打包到一个已知的全局对象类中来减少全局对象的数量。与将`Log`,`FileSystem`,
-    和	`AudioPlayer`变为单件不同：
+    我们可以通过将全局对象类统统包装到一个里面来减少数量。那么，除了挨个创建`Log`, `FileSystem`, 和`AudioPlayer`的单例外，我们可以：
 
     ```
     class Game
@@ -1025,27 +989,23 @@ other ways our codebase can get access to an object:
     
     **通过服务定位器来访问。** 到现在为止，我们假设全局类就是像`Game`那样的具体类。另外一个选择
     就是定义一个类专门用来给对象做全局访问。这个模式被称之为 <a class="pattern"
-    href="service-locator.html">服务定位器</a>并有单独的章节。
+    href="05.3-Service%20Locator.html">服务定位器</a>并有单独的章节。
 
 ## What's Left for Singleton 剩下的问题
 
 The question remains, where *should* we use the real Singleton pattern?
 Honestly, I've never used the full Gang of Four implementation in a game. To
 ensure single instantiation, I usually simply use a static class. If that
-doesn't work, I'll use a static flag to check at runtime that only one instance
-of the class is constructed.
+doesn't work, I'll use a static flag to check at runtime that only one instance of the class is constructed.
 
-我们还有一个问题，我们什么情况下使用真正的单件呢？老实说，我从来没有在游戏中使用GoF的完整实现。
-为了简单原则，我一般简单地使用一个静态类。如果这不能够满足，我将会使用一个静态的标志来在运行期检查
-只有一个类被创建了。
+我们还有一个问题，我们*应该*在什么情况下使用真正的单件呢？老实说，我从来没有在一个游戏中使用GoF的每个模式。为了确保只实例化一次，我通常只是简单地使用一个静态类。如果那不起作用，我就会用一个静态的标识位在运行时检查是否只有一个实例被创建。
 
 There are a couple of other chapters in this book that can also help here. The
-<a class="pattern" href="subclass-sandbox.html">Subclass Sandbox</a> pattern
+<a class="pattern" href="04.2-Subclass%20Sandbox.html">Subclass Sandbox</a> pattern
 gives instances of a class access to some shared state without making it
 globally available. The <a class="pattern" href="service-locator.html">Service
 Locator</a> pattern *does* make an object globally available, but it gives you
 more flexibility with how that object is configured.
 
-本书的一些其他章节也会有所帮助。 子类沙箱模式能够提供一些共享状态的访问指针而不必全局可见。服务定位器
-模式确实让一个对象全局可见，但是它给你这个物体如何配置的更多弹性。
+本书的一些其他章节也会有所帮助。<a class="pattern" href="04.2-Subclass%20Sandbox.html">子类沙箱模式</a>能够提供一些共享状态的访问指针而不必全局可见。<a class="pattern" href="05.3-Service%20Locator.html">服务定位器模式</a>确实让一个对象全局可见，但是给了你更灵活的方法去配置。
 


### PR DESCRIPTION
做了以下事情：
+ 干掉todos
+ 让一些中文读起来特别奇怪的句子不那么奇怪了（当然肯定有人会觉得我改过的没原来的好 :smiley_cat: ）
+ Lazy initialization 的翻译从“延迟初始化” 改成了 "惰性初始化"，对应地，Lazy也从“延迟”换成了“惰性”
+ 修正了若干释义不太正确的地方
+ 统一"C++"大小写
+ a标签链接在gitbook能正常工作（I wish）
+ 去掉了译文中换行符导致的空白